### PR TITLE
2 fixes: typo in Task2; failing build with missing python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jupyter-book
 matplotlib
 numpy
+sphinx-sitemap

--- a/task2_ROM3.md
+++ b/task2_ROM3.md
@@ -248,14 +248,14 @@ At a minimum, there should be one goal, each goal should have two objectives, an
    <ul style="font-size:8pt">
       <li><strong>Goal 1:&nbsp;</strong>Description of the goal<ul style="list-style-type: circle;">
                <li><strong>Objective 1.a:&nbsp;</strong>Description of the objective and how it supports the goal.<ul>
-                     <li><strong>Deliverable 1.a.i:&nbsp;</strong>Description of the objective and how it supports the objective.</li>
-                     <li><strong>Deliverable 1.a.ii:&nbsp;</strong>Description of the objective and how it supports the objective.</li>
-                     <li><strong>Deliverable 1.a.iii:&nbsp;</strong>Description of the objective and how it supports the objective.</li>
+                     <li><strong>Deliverable 1.a.i:&nbsp;</strong>Description of the deliverable and how it supports the objective.</li>
+                     <li><strong>Deliverable 1.a.ii:&nbsp;</strong>Description of the deliverable and how it supports the objective.</li>
+                     <li><strong>Deliverable 1.a.iii:&nbsp;</strong>Description of the deliverable and how it supports the objective.</li>
                   </ul>
                </li>
                <li><strong>Objective 1.b:&nbsp;</strong>Description of the objective and how it supports the goal.<ul>
-                     <li><strong>Deliverable 1.b.i:&nbsp;</strong>Description of the objective and how it supports the objective.</li>
-                     <li><strong>Deliverable 1.b.ii:&nbsp;</strong>Description of the objective and how it supports the objective.</li>
+                     <li><strong>Deliverable 1.b.i:&nbsp;</strong>Description of the deliverable and how it supports the objective.</li>
+                     <li><strong>Deliverable 1.b.ii:&nbsp;</strong>Description of the deliverable and how it supports the objective.</li>
                   </ul>
                </li>
          </ul>


### PR DESCRIPTION
Includes 2 fixes, detailed also in each commit:
1. Task2, section F example tables, F2 list states each deliverable as, "Description of the objective and how it supports the objective." 
Updated to read, "Description of the deliverable and how it supports the objective."

2. To verify changes, I tested building in a fresh virtual-env with `pip install -r requirements.txt` and `jupyter-book build .`, which failed on an error about a missing python module `sphinx-sitemap`.
This was the only necessary module that was not installed with the other modules in requirements.txt 
I added sphinx-sitemap to requirements.txt

-Joren Miner
jmine32@wgu.edu